### PR TITLE
Remove dependencies that are really dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,6 @@
   "dependencies": {
     "debug": "^2.2.0",
     "ffi": "^2.0.0",
-    "grunt": "^0.4.5",
-    "grunt-mocha-cli": "^2.0.0",
-    "load-grunt-tasks": "^3.3.0",
-    "mockery": "^1.4.0",
     "ref": "^1.2.0",
     "ref-struct": "^1.0.2",
     "ref-union": "^1.0.0"


### PR DESCRIPTION
This pull request removes four modules from the `dependencies` section that also appeared to be in the `devDepedencies` section and only used during testing and linting.
