### PR TITLE
Add npm ignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+.vscode
+test
+.beautifyrc
+.jscsrc
+.jshintrc
+.npmignore
+appveyor.yml
+*.gif
+*.jpg
+Gruntfile.js
+jsconfig.json


### PR DESCRIPTION
This pull requests add an `.npmignore` file that includes linting, testing, config, and image files.

This reduces the download size when running `npm install windows-registry` from `466K` to `7.4K`.
