### PR TITLE
Fix REG_DWORD_LITTLE_ENDIAN definition.

### DIFF
--- a/lib/windef.js
+++ b/lib/windef.js
@@ -39,7 +39,7 @@ module.exports = {
         REG_BINARY: 3,
         REG_DWORD: 4,
         REG_DWORD_BIG_ENDIAN: 5,
-        REG_DWORD_LITTLE_ENDIAN: 6,
+        REG_DWORD_LITTLE_ENDIAN: 4,
         REG_LINK: 6,
         REG_MULTI_SZ: 7,
         REG_RESOURCE_LIST: 8


### PR DESCRIPTION
REG_DWORD_LITTLE_ENDIAN is 4 not 6.
according to c:/program files (x86)/Windows Kits/8.0/Include/um/winnt.h