### PR TITLE
Add check for Windows platform

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,12 @@
-module.exports = {
-    registry: require('./lib/registry'),
-    error: require('./lib/error'),
-    types: require('./lib/types'),
-    windef: require('./lib/windef'),
-    Key: require('./lib/key'),
-    utils: require('./lib/utils')
-};
+if (process.platform == "win32") {
+	module.exports = {
+		registry: require('./lib/registry'),
+		error: require('./lib/error'),
+		types: require('./lib/types'),
+		windef: require('./lib/windef'),
+		Key: require('./lib/key'),
+		utils: require('./lib/utils')
+	};
+} else {
+	module.exports = void 0;
+}


### PR DESCRIPTION
Now we can safely import/require this library without crashing under
non-Windows environment.