### PR TITLE
REG_DWORD did not work, it would not write anything to the Registry. …

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -109,7 +109,8 @@ var api = {
             case windef.REG_VALUE_TYPE.REG_DWORD:
             case windef.REG_VALUE_TYPE.REG_DWORD_BIG_ENDIAN:
             case windef.REG_VALUE_TYPE.REG_DWORD_LITTLE_ENDIAN:
-                buffer = new Buffer(4, value);
+                buffer = Buffer.from(value);
+                byte = ref.alloc(types.LPDWORD, buffer);
                 result = advApi.RegSetValueExA(key.handle.deref(), valueName, null, valueType, byte.deref(), buffer.length);
                 break;
             default:


### PR DESCRIPTION
…Updated so that users enter an octet array and that octet array is assumed four characters.

Attempted to write a DWORD and there was an  exception because byte was not defined. Defined byte as an allocation of types.LPDWORD. 

The ''new Buffer(4, value)'' is not a value constructor and always created a buffer of all 0's of length four. Put the burden on the user to enter an array of octets (i.e. [1,0,0,0] to enter [0x00000001] into the registry.