### PR TITLE
Fix key and registry tests to work on Windows 10

### DIFF
--- a/test/key.js
+++ b/test/key.js
@@ -1,4 +1,4 @@
-/* global describe, it */
+/* global describe, it, before */
 'use strict';
 require('./test_helper');
 var assert = require('assert'),
@@ -7,34 +7,47 @@ var assert = require('assert'),
 
 describe('Key Open Tests', () => {
     it('Should create a key given a subkey', () => {
-        var key = new Key(windef.HKEY.HKEY_CLASSES_ROOT, '.txt', windef.KEY_ACCESS.KEY_ALL_ACCESS);
+        var key = new Key(windef.HKEY.HKEY_CLASSES_ROOT, '.txt', windef.KEY_ACCESS.KEY_READ);
         assert(key.handle !== null && key.handle !== undefined);
         key.close();
     });
 
     it('Should open a subkey provided a previously opened key', () => {
-        var key = new Key(windef.HKEY.HKEY_CLASSES_ROOT, '', windef.KEY_ACCESS.KEY_ALL_ACCESS);
-        var key2 = key.openSubKey('.txt', windef.KEY_ACCESS.KEY_ALL_ACCESS);
+        var key = new Key(windef.HKEY.HKEY_CLASSES_ROOT, '', windef.KEY_ACCESS.KEY_READ);
+        var key2 = key.openSubKey('.txt', windef.KEY_ACCESS.KEY_READ);
         assert(key2.handle !== null && key2.handle !== undefined);
         key.close();
         key2.close();
     });
 
     it('Should properly close', () => {
-        var key = new Key(windef.HKEY.HKEY_CLASSES_ROOT, '.txt', windef.KEY_ACCESS.KEY_ALL_ACCESS);
+        var key = new Key(windef.HKEY.HKEY_CLASSES_ROOT, '.txt', windef.KEY_ACCESS.KEY_READ);
         key.close();
 
         // ensure that the key is actually closed by trying to open a subkey
         // which should fail
         assert.throws(() => {
-            key.openSubKey('OpenWithList', windef.KEY_ACCESS.KEY_ALL_ACCESS);
+            key.openSubKey('OpenWithList', windef.KEY_ACCESS.KEY_READ);
         });
     });
 });
 
 describe('Create Key Tests', function () {
+    before(() => {
+        // We perform all testing that modifies the registry under HKCU\Software\windows-registry-node.
+        // Ensure this exists.
+        var key = new Key(windef.HKEY.HKEY_CURRENT_USER, 'Software', windef.KEY_ACCESS.KEY_READ);
+        try {
+            key.createSubKey('windows-registry-node', windef.KEY_ACCESS.KEY_ALL_ACCESS);
+        }
+        catch (error) {
+            console.log('Error creating test environment root key');
+            throw error;
+        }
+    });
+
     it('Should create a new key and Delete it', () => {
-        var key = new Key(windef.HKEY.HKEY_CLASSES_ROOT, '.txt', windef.KEY_ACCESS.KEY_ALL_ACCESS);
+        var key = new Key(windef.HKEY.HKEY_CURRENT_USER, 'Software\\windows-registry-node', windef.KEY_ACCESS.KEY_ALL_ACCESS);
 
         assert(key.handle !== undefined);
         assert(key.handle !== null);
@@ -46,8 +59,9 @@ describe('Create Key Tests', function () {
         assert(createdKey.path === '\test_key_name');
 
         createdKey.deleteKey();
+
         assert.throws(() => {
-            key.openSubKey('\test_key_name', windef.KEY_ACCESS.KEY_ALL_ACCESS);
+            key.openSubKey('\test_key_name', windef.KEY_ACCESS.KEY_READ);
         }, (err) => {
             assert(err.indexOf('ERROR_FILE_NOT_FOUND') > -1);
             return true;
@@ -58,8 +72,21 @@ describe('Create Key Tests', function () {
 });
 
 describe('Set / Query Value Tests', function () {
+    before(() => {
+        // We perform all testing that modifies the registry under HKCU\Software\windows-registry-node.
+        // Ensure this exists.
+        var key = new Key(windef.HKEY.HKEY_CURRENT_USER, 'Software', windef.KEY_ACCESS.KEY_READ);
+        try {
+            key.createSubKey('windows-registry-node', windef.KEY_ACCESS.KEY_ALL_ACCESS);
+        }
+        catch (error) {
+            console.log('Error creating test environment root key');
+            throw error;
+        }
+    });
+
     it('Should set and read REG_SZ Value', () => {
-        var key = new Key(windef.HKEY.HKEY_CLASSES_ROOT, '.txt', windef.KEY_ACCESS.KEY_ALL_ACCESS);
+        var key = new Key(windef.HKEY.HKEY_CURRENT_USER, 'Software\\windows-registry-node', windef.KEY_ACCESS.KEY_ALL_ACCESS);
 
         assert(key.handle !== null && key.handle !== undefined);
 
@@ -68,6 +95,8 @@ describe('Set / Query Value Tests', function () {
         var value = key.getValue('test_value_name');
 
         assert.equal(value, 'test_value');
+
+        key.deleteValue('test_value_name');
         key.close();
     });
 });


### PR DESCRIPTION
- Open keys in HKCR as read-only, not all access
- Create a new key HKCU\Software\windows-registry-node for read/write tests. (This key is not cleaned up on test completion, in case there's a problem with the delete code.)

I haven't fixed the file association or elevation tests though, which are still failing for me. The file association code tries to open HKCR as all access which fails for me even with elevation, and the elevation test times out before the confirmation dialog opens.